### PR TITLE
fix wrong usage limit fetch

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,8 +4,8 @@ const budget = {
   "blocked@example.com": { limit: 0, days: 1 }, // Blocked user: zero limit stops all operations
   "user@example.com": { limit: 10.0, days: 30 }, // Premium user with monthly high-volume allocation
   "@example.com": { limit: 1.0, days: 7 }, // Domain-wide policy: moderate weekly quota for organization
-  "*@study.iitm.ac.in": { limit: 1.0, days: 30 }, // IITM Students: $1 / month
-  "*@ds.study.iitm.ac.in": { limit: 1.0, days: 30 }, // IITM Students: $1 / month
+  "@study.iitm.ac.in": { limit: 1.0, days: 30 }, // IITM Students: $1 / month
+  "@ds.study.iitm.ac.in": { limit: 1.0, days: 30 }, // IITM Students: $1 / month
   "*@straive.com": { limit: 1.0, days: 1 }, // Straive: $1 / day
   "*@gramener.com": { limit: 1.0, days: 1 }, // Gramener: $1 / day
 };


### PR DESCRIPTION
It was fetching wrong usage limit for IITM students because of key mismatch on [line no. 40 of worker.js](https://github.com/sanand0/aipipe/blob/main/src/worker.js#L40), it was taking domain as: `@ds.study.iitm.ac.in` but in config it was set as `*@ds.study.iitm.ac.in`.