### PR TITLE
fix: Prevent open redirect; refactor usage view. Fixes #11

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -68,6 +68,8 @@ async function init() {
 
   if (redirect) {
     const url = new URL(redirect, window.location.origin);
+    // Restrict to same-origin redirects
+    if (url.origin !== window.location.origin) return;
     url.searchParams.append("aipipe_token", token);
     url.searchParams.append("aipipe_email", email);
     window.location.href = url.toString();

--- a/public/usage.js
+++ b/public/usage.js
@@ -1,10 +1,11 @@
+import { render, html } from "https://cdn.jsdelivr.net/npm/lit-html@3/+esm";
+
 async function showUsage($usage, token, email) {
   const { cost, limit, days, usage } = await fetch("usage", { headers: { Authorization: `Bearer ${token}` } }).then(
     (r) => r.json(),
   );
 
-  // Display usage summary and table
-  $usage.innerHTML = /* html */ `
+  const view = html`
     <div class="card text-bg-primary shadow-lg mb-3">
       <div class="card-body">
         <h3 class="card-title h5">${email}</h3>
@@ -22,18 +23,17 @@ async function showUsage($usage, token, email) {
         </tr>
       </thead>
       <tbody>
-        ${usage
-          .map(
-            (day) => `
-              <tr>
-                <td>${day.date}</td>
-                <td>${(day.cost * 100).toFixed(5)}</td>
-              </tr>`,
-          )
-          .join("")}
+        ${usage.map(
+          (day) =>
+            html` <tr>
+              <td>${day.date}</td>
+              <td>${(day.cost * 100).toFixed(5)}</td>
+            </tr>`,
+        )}
       </tbody>
     </table>
   `;
+  render(view, $usage);
 }
 
 export { showUsage };


### PR DESCRIPTION
**Prevent open redirects**. Ensure that the `redirect` URL parameter in `public/login.js` only allows same-origin URLs. This mitigates a potential open redirect vulnerability, preventing attackers from redirecting users to arbitrary external websites.

**Refactor usage display**. Migrate the HTML rendering logic in `public/usage.js` to use `lit-html`. This enhances code maintainability and readability by leveraging a declarative templating library for dynamic UI elements.