### PR TITLE
Allow native API keys as alternative to AI Pipe keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,43 @@ uvx llm 'Hello' -m gpt-4o-mini --key $AIPIPE_TOKEN
 
 This will print something like `Hello! How can I assist you today?`
 
+## Native Provider API Keys
+
+You can also use your own provider API keys directly (instead of an AI Pipe Token). This is useful if you want to:
+
+- Bypass AI Pipe's cost tracking and budget limits
+- Use models that aren't yet in AI Pipe's pricing database
+- Handle billing directly with the provider
+
+Simply use your native API key in the `Authorization` header:
+
+```bash
+# OpenAI with native key (starts with sk-)
+curl https://aipipe.org/openai/v1/chat/completions \
+  -H "Authorization: Bearer sk-your-openai-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# OpenRouter with native key (starts with sk-or-)
+curl https://aipipe.org/openrouter/v1/chat/completions \
+  -H "Authorization: Bearer sk-or-your-openrouter-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+
+# Gemini with native key (starts with AIza)
+curl https://aipipe.org/geminiv1beta/models/gemini-2.5-flash-lite:generateContent \
+  -H "Authorization: Bearer AIzaSyYourGeminiKey" \
+  -H "Content-Type: application/json" \
+  -d '{"contents":[{"parts":[{"text":"Hello"}]}]}'
+```
+
+Native keys are detected by their prefix pattern:
+
+- **OpenAI / OpenRouter**: Keys starting with `sk-`
+- **Google Gemini**: Keys starting with `AIza`
+
+**Note**: Native API keys cannot access `/usage` or `/admin` endpoints, which require an AI Pipe Token.
+
 ## Developer Guide
 
 Paste this code into `index.html`, open it in a browser, and check your [DevTools Console](https://developer.chrome.com/docs/devtools/console)
@@ -98,12 +135,7 @@ Response:
   "email": "user@example.com",
   "days": 7,
   "cost": 0.000137,
-  "usage": [
-    {
-      "date": "2025-04-16",
-      "cost": 0.000137
-    }
-  ],
+  "usage": [{ "date": "2025-04-16", "cost": 0.000137 }],
   "limit": 0.1
 }
 ```
@@ -120,9 +152,7 @@ Response:
 
 ```json
 {
-  "args": {
-    "x": "1"
-  },
+  "args": { "x": "1" },
   "headers": {
     "Accept": "*/*",
     "Host": "httpbin.org",
@@ -185,16 +215,7 @@ curl https://aipipe.org/openrouter/v1/chat/completions \
 Response contains:
 
 ```jsonc
-{
-  "choices": [
-    {
-      "message": {
-        "role": "assistant",
-        "content": "..."
-      }
-    }
-  ]
-}
+{ "choices": [{ "message": { "role": "assistant", "content": "..." } }] }
 ```
 
 #### OpenRouter Image Generation
@@ -274,13 +295,10 @@ Response contains:
 
 ```jsonc
 {
-  "output": [
-    {
-      "role": "assistant",
-      "content": [{ "text": "2 + 2 equals 4." }]
-      // ...
-    }
-  ]
+  "output": [{
+    "role": "assistant",
+    "content": [{ "text": "2 + 2 equals 4." }] // ...
+  }]
 }
 ```
 
@@ -302,18 +320,12 @@ Response contains:
     {
       "object": "embedding",
       "index": 0,
-      "embedding": [
-        0.010576399,
-        -0.037246477
-        // ...
+      "embedding": [0.010576399, -0.037246477 // ...
       ]
     }
   ],
   "model": "text-embedding-3-small",
-  "usage": {
-    "prompt_tokens": 8,
-    "total_tokens": 8
-  }
+  "usage": { "prompt_tokens": 8, "total_tokens": 8 }
 }
 ```
 
@@ -324,7 +336,7 @@ Response contains:
 **Example**: Make a [generateContent](https://ai.google.dev/gemini-api/docs) request
 
 ```bash
-curl https://aipipe.org/geminiv1beta/models/gemini-1.5-flash:generateContent \
+curl https://aipipe.org/geminiv1beta/models/gemini-2.5-flash-lite:generateContent \
   -H "x-goog-api-key: $AIPIPE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"parts":[{"text":"What is 2 + 2?"}]}]}'
@@ -334,12 +346,8 @@ Response contains:
 
 ```jsonc
 {
-  "candidates": [
-    {
-      "content": { "parts": [{ "text": "2 + 2 is 4." }] }
-    }
-  ],
-  "modelVersion": "gemini-1.5-flash",
+  "candidates": [{ "content": { "parts": [{ "text": "2 + 2 is 4." }] } }],
+  "modelVersion": "gemini-2.5-flash-lite",
   "usageMetadata": {
     "promptTokenCount": 8,
     "candidatesTokenCount": 8,
@@ -549,13 +557,7 @@ Response:
 
 ```jsonc
 {
-  "data": [
-    {
-      "email": "test@example.com",
-      "date": "2025-04-18",
-      "cost": 25.5
-    }
-    // ...
+  "data": [{ "email": "test@example.com", "date": "2025-04-18", "cost": 25.5 } // ...
   ]
 }
 ```
@@ -569,9 +571,7 @@ curl "https://aipipe.org/admin/token?email=user@example.com" -H "Authorization: 
 Response:
 
 ```json
-{
-  "token": "eyJhbGciOiJIUzI1NiI..."
-}
+{ "token": "eyJhbGciOiJIUzI1NiI..." }
 ```
 
 **`POST /admin/cost`**: Overwrite the cost usage for a user on a specific date. Only for admins.
@@ -586,9 +586,7 @@ curl https://aipipe.org/admin/cost \
 Response:
 
 ```json
-{
-  "message": "Cost for user@example.com on 2025-04-18 set to 1.23"
-}
+{ "message": "Cost for user@example.com on 2025-04-18 set to 1.23" }
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ export OPENAI_BASE_URL=https://aipipe.org/openai/v1
 Now you can run:
 
 ```bash
-uvx openai api chat.completions.create -m gpt-4.1-nano -g user "Hello"
+uvx openai api chat.completions.create -m gpt-5-nano -g user "Hello"
 ```
 
 ... or:
 
 ```bash
-uvx llm 'Hello' -m gpt-4o-mini --key $AIPIPE_TOKEN
+uvx llm 'Hello' -m gpt-5-nano --key $AIPIPE_TOKEN
 ```
 
 This will print something like `Hello! How can I assist you today?`
@@ -55,13 +55,13 @@ Simply use your native API key in the `Authorization` header:
 curl https://aipipe.org/openai/v1/chat/completions \
   -H "Authorization: Bearer sk-your-openai-key" \
   -H "Content-Type: application/json" \
-  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+  -d '{"model": "gpt-5-nano", "messages": [{"role": "user", "content": "Hello"}]}'
 
 # OpenRouter with native key (starts with sk-or-)
 curl https://aipipe.org/openrouter/v1/chat/completions \
   -H "Authorization: Bearer sk-or-your-openrouter-key" \
   -H "Content-Type: application/json" \
-  -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+  -d '{"model": "openai/gpt-5-nano", "messages": [{"role": "user", "content": "Hello"}]}'
 
 # Gemini with native key (starts with AIza)
 curl https://aipipe.org/geminiv1beta/models/gemini-2.5-flash-lite:generateContent \
@@ -92,7 +92,7 @@ Paste this code into `index.html`, open it in a browser, and check your [DevTool
     method: "POST",
     headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
     body: JSON.stringify({
-      model: "openai/gpt-4o-mini",
+      model: "openai/gpt-5-nano",
       messages: [{ role: "user", content: "What is 2 + 2?" }],
     }),
   }).then((r) => r.json());
@@ -288,7 +288,7 @@ Response contains:
 curl https://aipipe.org/openai/v1/responses \
   -H "Authorization: Bearer $AIPIPE_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"model": "gpt-4.1-nano", "input": "What is 2 + 2?" }'
+  -d '{"model": "gpt-5-nano", "input": "What is 2 + 2?" }'
 ```
 
 Response contains:

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "lint": "dprint fmt -c https://raw.githubusercontent.com/sanand0/scripts/refs/heads/main/dprint.jsonc && npx -y oxlint --fix",
     "prepublishOnly": "npm run lint"
   },
-  "prettier": {
-    "printWidth": 120
-  },
+  "prettier": { "printWidth": 120 },
   "type": "module",
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.9.13",
@@ -22,7 +20,5 @@
     "vitest": "^3.2.4",
     "wrangler": "^4.12.0"
   },
-  "dependencies": {
-    "jose": "^6.0.10"
-  }
+  "dependencies": { "jose": "^6.0.10" }
 }

--- a/prompts/2025-10-19-vitest-migration.md
+++ b/prompts/2025-10-19-vitest-migration.md
@@ -110,9 +110,7 @@ test/
     "request": {
       "method": "GET",
       "path": "/openrouter/v1/models",
-      "headers": {
-        "Authorization": "Bearer {{token}}"
-      },
+      "headers": { "Authorization": "Bearer {{token}}" },
       "body": null
     },
     "env": {
@@ -126,9 +124,7 @@ test/
   ```json
   {
     "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
+    "headers": { "Content-Type": "application/json" },
     "body": {
       "data": [
         {
@@ -141,13 +137,7 @@ test/
   ```
 - **Durable Object seed** (`test/fixtures/states/durable-usage.json`):
   ```json
-  {
-    "emails": {
-      "test@example.com": {
-        "2025-01-01": 25.0
-      }
-    }
-  }
+  { "emails": { "test@example.com": { "2025-01-01": 25.0 } } }
   ```
 
 ### Helper Utilities

--- a/tests/fixtures/durable-usage.state.json
+++ b/tests/fixtures/durable-usage.state.json
@@ -1,9 +1,4 @@
 {
-  "test@example.com": [
-    { "daysAgo": 1, "cost": 12.5 },
-    { "daysAgo": 0, "cost": 7.5 }
-  ],
-  "domain-user@example.com": [
-    { "daysAgo": 0, "cost": 5 }
-  ]
+  "test@example.com": [{ "daysAgo": 1, "cost": 12.5 }, { "daysAgo": 0, "cost": 7.5 }],
+  "domain-user@example.com": [{ "daysAgo": 0, "cost": 5 }]
 }

--- a/tests/fixtures/gemini-embedding.json
+++ b/tests/fixtures/gemini-embedding.json
@@ -2,59 +2,21 @@
   "description": "Gemini embedding",
   "method": "POST",
   "path": "/geminiv1beta/models/gemini-embedding-001:embedContent",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "gemini-embedding-001",
-    "content": {
-      "parts": [
-        {
-          "text": "Embed this"
-        }
-      ]
-    }
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "gemini-embedding-001", "content": { "parts": [{ "text": "Embed this" }] } },
   "mock": {
     "origin": "https://generativelanguage.googleapis.com",
     "path": "/v1beta/models/gemini-embedding-001:embedContent",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "application/json"
-      },
-      "body": {
-        "embedding": {
-          "values": [
-            0.12,
-            -0.04,
-            0.33
-          ]
-        },
-        "usageMetadata": {
-          "promptTokenCount": 8
-        }
-      }
+      "headers": { "content-type": "application/json" },
+      "body": { "embedding": { "values": [0.12, -0.04, 0.33] }, "usageMetadata": { "promptTokenCount": 8 } }
     }
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
-    "body": {
-      "embedding": {
-        "values": [
-          0.12,
-          -0.04,
-          0.33
-        ]
-      },
-      "usageMetadata": {
-        "promptTokenCount": 8
-      }
-    }
+    "headers": { "content-type": "application/json" },
+    "body": { "embedding": { "values": [0.12, -0.04, 0.33] }, "usageMetadata": { "promptTokenCount": 8 } }
   }
 }

--- a/tests/fixtures/gemini-generate-stream.json
+++ b/tests/fixtures/gemini-generate-stream.json
@@ -2,30 +2,15 @@
   "description": "Gemini streaming completion",
   "method": "POST",
   "path": "/geminiv1beta/models/gemini-2.5-flash-lite:streamGenerateContent?alt=sse",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "contents": [
-      {
-        "parts": [
-          {
-            "text": "Stream hi"
-          }
-        ]
-      }
-    ]
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "contents": [{ "parts": [{ "text": "Stream hi" }] }] },
   "mock": {
     "origin": "https://generativelanguage.googleapis.com",
     "path": "/v1beta/models/gemini-2.5-flash-lite:streamGenerateContent?alt=sse",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "text/event-stream"
-      },
+      "headers": { "content-type": "text/event-stream" },
       "sse": [
         "data: {\"response\":{\"modelVersion\":\"gemini-2.5-flash-lite\",\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}}",
         "data: {\"response\":{\"modelVersion\":\"gemini-2.5-flash-lite\",\"usageMetadata\":{\"promptTokenCount\":12,\"candidatesTokenCount\":8}}}",
@@ -35,9 +20,7 @@
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "text/event-stream"
-    },
+    "headers": { "content-type": "text/event-stream" },
     "sse": [
       "data: {\"response\":{\"modelVersion\":\"gemini-2.5-flash-lite\",\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}]}}]}}",
       "data: {\"response\":{\"modelVersion\":\"gemini-2.5-flash-lite\",\"usageMetadata\":{\"promptTokenCount\":12,\"candidatesTokenCount\":8}}}",

--- a/tests/fixtures/gemini-generate.json
+++ b/tests/fixtures/gemini-generate.json
@@ -2,71 +2,27 @@
   "description": "Gemini text completion",
   "method": "POST",
   "path": "/geminiv1beta/models/gemini-2.5-flash-lite:generateContent",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "gemini-2.5-flash-lite",
-    "contents": [
-      {
-        "parts": [
-          {
-            "text": "Say hi"
-          }
-        ]
-      }
-    ]
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "gemini-2.5-flash-lite", "contents": [{ "parts": [{ "text": "Say hi" }] }] },
   "mock": {
     "origin": "https://generativelanguage.googleapis.com",
     "path": "/v1beta/models/gemini-2.5-flash-lite:generateContent",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "application/json"
-      },
+      "headers": { "content-type": "application/json" },
       "body": {
-        "candidates": [
-          {
-            "content": {
-              "parts": [
-                {
-                  "text": "Hello from Gemini"
-                }
-              ]
-            }
-          }
-        ],
-        "usageMetadata": {
-          "promptTokenCount": 10,
-          "candidatesTokenCount": 6
-        }
+        "candidates": [{ "content": { "parts": [{ "text": "Hello from Gemini" }] } }],
+        "usageMetadata": { "promptTokenCount": 10, "candidatesTokenCount": 6 }
       }
     }
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
+    "headers": { "content-type": "application/json" },
     "body": {
-      "candidates": [
-        {
-          "content": {
-            "parts": [
-              {
-                "text": "Hello from Gemini"
-              }
-            ]
-          }
-        }
-      ],
-      "usageMetadata": {
-        "promptTokenCount": 10,
-        "candidatesTokenCount": 6
-      }
+      "candidates": [{ "content": { "parts": [{ "text": "Hello from Gemini" }] } }],
+      "usageMetadata": { "promptTokenCount": 10, "candidatesTokenCount": 6 }
     }
   }
 }

--- a/tests/fixtures/gemini.scenarios.json
+++ b/tests/fixtures/gemini.scenarios.json
@@ -3,29 +3,18 @@
     "name": "generate-content",
     "request": "gemini-generate",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "gemini-generate.json" },
-      "usageDelta": 0.0000034
-    }
+    "expect": { "status": 200, "body": { "responseFixture": "gemini-generate.json" }, "usageDelta": 0.0000034 }
   },
   {
     "name": "generate-content-stream",
     "request": "gemini-generate-stream",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "usageDelta": 0.0000044
-    }
+    "expect": { "status": 200, "usageDelta": 0.0000044 }
   },
   {
     "name": "embed-content",
     "request": "gemini-embedding",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "gemini-embedding.json" },
-      "usageDelta": 0.0000012
-    }
+    "expect": { "status": 200, "body": { "responseFixture": "gemini-embedding.json" }, "usageDelta": 0.0000012 }
   }
 ]

--- a/tests/fixtures/openai-chat-completions.json
+++ b/tests/fixtures/openai-chat-completions.json
@@ -2,72 +2,37 @@
   "description": "Chat completion request",
   "method": "POST",
   "path": "/openai/v1/chat/completions",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "gpt-5-nano",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Say hello"
-      }
-    ]
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "gpt-5-nano", "messages": [{ "role": "user", "content": "Say hello" }] },
   "mock": {
     "origin": "https://api.openai.com",
     "path": "/v1/chat/completions",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "application/json"
-      },
+      "headers": { "content-type": "application/json" },
       "body": {
         "id": "chatcmpl-test",
         "object": "chat.completion",
         "model": "gpt-5-nano",
         "choices": [
-          {
-            "index": 0,
-            "message": {
-              "role": "assistant",
-              "content": "Hello there!"
-            },
-            "finish_reason": "stop"
-          }
+          { "index": 0, "message": { "role": "assistant", "content": "Hello there!" }, "finish_reason": "stop" }
         ],
-        "usage": {
-          "prompt_tokens": 12,
-          "completion_tokens": 6
-        }
+        "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
       }
     }
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
+    "headers": { "content-type": "application/json" },
     "body": {
       "id": "chatcmpl-test",
       "object": "chat.completion",
       "model": "gpt-5-nano",
       "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": "Hello there!"
-          },
-          "finish_reason": "stop"
-        }
+        { "index": 0, "message": { "role": "assistant", "content": "Hello there!" }, "finish_reason": "stop" }
       ],
-      "usage": {
-        "prompt_tokens": 12,
-        "completion_tokens": 6
-      }
+      "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
     }
   }
 }

--- a/tests/fixtures/openai-embedding.json
+++ b/tests/fixtures/openai-embedding.json
@@ -2,65 +2,31 @@
   "description": "Embed text via OpenAI embeddings endpoint",
   "method": "POST",
   "path": "/openai/v1/embeddings",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "text-embedding-3-small",
-    "input": "Testing embeddings"
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "text-embedding-3-small", "input": "Testing embeddings" },
   "mock": {
     "origin": "https://api.openai.com",
     "path": "/v1/embeddings",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "application/json"
-      },
+      "headers": { "content-type": "application/json" },
       "body": {
         "object": "list",
-        "data": [
-          {
-            "index": 0,
-            "object": "embedding",
-            "embedding": [
-              0.0123,
-              -0.0456,
-              0.0789
-            ]
-          }
-        ],
+        "data": [{ "index": 0, "object": "embedding", "embedding": [0.0123, -0.0456, 0.0789] }],
         "model": "text-embedding-3-small",
-        "usage": {
-          "prompt_tokens": 8
-        }
+        "usage": { "prompt_tokens": 8 }
       }
     }
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
+    "headers": { "content-type": "application/json" },
     "body": {
       "object": "list",
-      "data": [
-        {
-          "index": 0,
-          "object": "embedding",
-          "embedding": [
-            0.0123,
-            -0.0456,
-            0.0789
-          ]
-        }
-      ],
+      "data": [{ "index": 0, "object": "embedding", "embedding": [0.0123, -0.0456, 0.0789] }],
       "model": "text-embedding-3-small",
-      "usage": {
-        "prompt_tokens": 8
-      }
+      "usage": { "prompt_tokens": 8 }
     }
   }
 }

--- a/tests/fixtures/openai-responses-stream.json
+++ b/tests/fixtures/openai-responses-stream.json
@@ -2,24 +2,15 @@
   "description": "Responses endpoint with streaming",
   "method": "POST",
   "path": "/openai/v1/responses",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "gpt-5-nano",
-    "input": "Say something witty",
-    "stream": true
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "gpt-5-nano", "input": "Say something witty", "stream": true },
   "mock": {
     "origin": "https://api.openai.com",
     "path": "/v1/responses",
     "method": "POST",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "text/event-stream"
-      },
+      "headers": { "content-type": "text/event-stream" },
       "sse": [
         "data: {\"id\":\"resp-test\",\"object\":\"response.output_text.delta\",\"model\":\"gpt-5-nano\",\"output\":[{\"content\":[{\"text\":\"Witty line\",\"type\":\"output_text\"}],\"id\":\"output-1\",\"type\":\"output_text\"}]}",
         "data: {\"id\":\"resp-test\",\"object\":\"response.completed\",\"model\":\"gpt-5-nano\",\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":10}}",
@@ -29,9 +20,7 @@
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "text/event-stream"
-    },
+    "headers": { "content-type": "text/event-stream" },
     "sse": [
       "data: {\"id\":\"resp-test\",\"object\":\"response.output_text.delta\",\"model\":\"gpt-5-nano\",\"output\":[{\"content\":[{\"text\":\"Witty line\",\"type\":\"output_text\"}],\"id\":\"output-1\",\"type\":\"output_text\"}]}",
       "data: {\"id\":\"resp-test\",\"object\":\"response.completed\",\"model\":\"gpt-5-nano\",\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":10}}",

--- a/tests/fixtures/openai.scenarios.json
+++ b/tests/fixtures/openai.scenarios.json
@@ -3,29 +3,18 @@
     "name": "embedding",
     "request": "openai-embedding",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "openai-embedding.json" },
-      "usageDelta": 0.00000016
-    }
+    "expect": { "status": 200, "body": { "responseFixture": "openai-embedding.json" }, "usageDelta": 0.00000016 }
   },
   {
     "name": "chat-completion",
     "request": "openai-chat-completions",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "openai-chat-completions.json" },
-      "usageDelta": 0.000003
-    }
+    "expect": { "status": 200, "body": { "responseFixture": "openai-chat-completions.json" }, "usageDelta": 0.000003 }
   },
   {
     "name": "responses-stream",
     "request": "openai-responses-stream",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "usageDelta": 0.00000475
-    }
+    "expect": { "status": 200, "usageDelta": 0.00000475 }
   }
 ]

--- a/tests/fixtures/openrouter-budget-blocked.request.json
+++ b/tests/fixtures/openrouter-budget-blocked.request.json
@@ -2,7 +2,5 @@
   "description": "Blocked user hitting models endpoint",
   "method": "GET",
   "path": "/openrouter/v1/models",
-  "headers": {
-    "Authorization": "Bearer {{token}}"
-  }
+  "headers": { "Authorization": "Bearer {{token}}" }
 }

--- a/tests/fixtures/openrouter-chat-stream.json
+++ b/tests/fixtures/openrouter-chat-stream.json
@@ -2,18 +2,10 @@
   "description": "Streaming OpenRouter chat completion",
   "method": "POST",
   "path": "/openrouter/v1/chat/completions",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
   "body": {
     "model": "google/gemini-2.5-flash-lite",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Stream a greeting"
-      }
-    ],
+    "messages": [{ "role": "user", "content": "Stream a greeting" }],
     "stream": true
   },
   "mock": [
@@ -23,9 +15,7 @@
       "method": "POST",
       "response": {
         "status": 200,
-        "headers": {
-          "content-type": "text/event-stream"
-        },
+        "headers": { "content-type": "text/event-stream" },
         "sse": [
           "data: {\"response\":{\"model\":\"google/gemini-2.5-flash-lite\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}}",
           "data: {\"response\":{\"model\":\"google/gemini-2.5-flash-lite\",\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":10}}}",
@@ -36,9 +26,7 @@
   ],
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "text/event-stream"
-    },
+    "headers": { "content-type": "text/event-stream" },
     "sse": [
       "data: {\"response\":{\"model\":\"google/gemini-2.5-flash-lite\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}}",
       "data: {\"response\":{\"model\":\"google/gemini-2.5-flash-lite\",\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":10}}}",

--- a/tests/fixtures/openrouter-chat.json
+++ b/tests/fixtures/openrouter-chat.json
@@ -2,19 +2,8 @@
   "description": "Non-streaming OpenRouter chat completion",
   "method": "POST",
   "path": "/openrouter/v1/chat/completions",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "model": "google/gemini-2.5-flash-lite",
-    "messages": [
-      {
-        "role": "user",
-        "content": "Say hello"
-      }
-    ]
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "model": "google/gemini-2.5-flash-lite", "messages": [{ "role": "user", "content": "Say hello" }] },
   "mock": [
     {
       "origin": "https://openrouter.ai",
@@ -22,52 +11,32 @@
       "method": "POST",
       "response": {
         "status": 200,
-        "headers": {
-          "content-type": "application/json"
-        },
+        "headers": { "content-type": "application/json" },
         "body": {
           "id": "chatcmpl-openrouter",
           "model": "google/gemini-2.5-flash-lite",
           "choices": [
             {
               "index": 0,
-              "message": {
-                "role": "assistant",
-                "content": "Hello from OpenRouter"
-              },
+              "message": { "role": "assistant", "content": "Hello from OpenRouter" },
               "finish_reason": "stop"
             }
           ],
-          "usage": {
-            "prompt_tokens": 12,
-            "completion_tokens": 6
-          }
+          "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
         }
       }
     }
   ],
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
+    "headers": { "content-type": "application/json" },
     "body": {
       "id": "chatcmpl-openrouter",
       "model": "google/gemini-2.5-flash-lite",
       "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": "Hello from OpenRouter"
-          },
-          "finish_reason": "stop"
-        }
+        { "index": 0, "message": { "role": "assistant", "content": "Hello from OpenRouter" }, "finish_reason": "stop" }
       ],
-      "usage": {
-        "prompt_tokens": 12,
-        "completion_tokens": 6
-      }
+      "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
     }
   }
 }

--- a/tests/fixtures/openrouter-chat.scenarios.json
+++ b/tests/fixtures/openrouter-chat.scenarios.json
@@ -3,19 +3,12 @@
     "name": "chat-completion",
     "request": "openrouter-chat",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "openrouter-chat.json" },
-      "usageDelta": 0.00024
-    }
+    "expect": { "status": 200, "body": { "responseFixture": "openrouter-chat.json" }, "usageDelta": 0.00024 }
   },
   {
     "name": "chat-completion-stream",
     "request": "openrouter-chat-stream",
     "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "usageDelta": 0.00035
-    }
+    "expect": { "status": 200, "usageDelta": 0.00035 }
   }
 ]

--- a/tests/fixtures/openrouter-invalid-salt.request.json
+++ b/tests/fixtures/openrouter-invalid-salt.request.json
@@ -2,7 +2,5 @@
   "description": "GET with token minted without configured salt",
   "method": "GET",
   "path": "/openrouter/v1/models",
-  "headers": {
-    "Authorization": "Bearer {{token}}"
-  }
+  "headers": { "Authorization": "Bearer {{token}}" }
 }

--- a/tests/fixtures/openrouter-missing-auth.request.json
+++ b/tests/fixtures/openrouter-missing-auth.request.json
@@ -1,5 +1,1 @@
-{
-  "description": "Direct GET without Authorization header",
-  "method": "GET",
-  "path": "/openrouter/v1/models"
-}
+{ "description": "Direct GET without Authorization header", "method": "GET", "path": "/openrouter/v1/models" }

--- a/tests/fixtures/openrouter-models.scenarios.json
+++ b/tests/fixtures/openrouter-models.scenarios.json
@@ -14,85 +14,40 @@
   {
     "name": "cors-requested-header",
     "request": "openrouter-options-custom",
-    "expect": {
-      "status": 200,
-      "headers": {
-        "access-control-allow-headers": "X-Custom-Header"
-      }
-    }
+    "expect": { "status": 200, "headers": { "access-control-allow-headers": "X-Custom-Header" } }
   },
   {
     "name": "authorization-required",
     "request": "openrouter-missing-auth",
-    "expect": {
-      "status": 401,
-      "body": {
-        "messageIncludes": "Missing Authorization"
-      }
-    }
+    "expect": { "status": 401, "body": { "messageIncludes": "Missing Authorization" } }
   },
   {
     "name": "invalid-jwt-token",
     "request": "openrouter-unauthorized",
-    "expect": {
-      "status": 401,
-      "body": {
-        "messageIncludes": "invalid"
-      }
-    }
+    "expect": { "status": 401, "body": { "messageIncludes": "invalid" } }
   },
   {
     "name": "valid-jwt-token",
     "request": "openrouter-success",
-    "token": {
-      "email": "test@example.com"
-    },
-    "expect": {
-      "status": 200,
-      "body": {
-        "responseFixture": "openrouter-success.json"
-      }
-    }
+    "token": { "email": "test@example.com" },
+    "expect": { "status": 200, "body": { "responseFixture": "openrouter-success.json" } }
   },
   {
     "name": "invalid-salt",
     "request": "openrouter-invalid-salt",
-    "token": {
-      "email": "user@example.com",
-      "useSalt": false
-    },
-    "expect": {
-      "status": 401,
-      "body": {
-        "messageIncludes": "no longer valid"
-      }
-    }
+    "token": { "email": "user@example.com", "useSalt": false },
+    "expect": { "status": 401, "body": { "messageIncludes": "no longer valid" } }
   },
   {
     "name": "valid-salt",
     "request": "openrouter-success",
-    "token": {
-      "email": "user@example.com",
-      "useSalt": true
-    },
-    "expect": {
-      "status": 200,
-      "body": {
-        "responseFixture": "openrouter-success.json"
-      }
-    }
+    "token": { "email": "user@example.com", "useSalt": true },
+    "expect": { "status": 200, "body": { "responseFixture": "openrouter-success.json" } }
   },
   {
     "name": "budget-limit-exceeded",
     "request": "openrouter-budget-blocked",
-    "token": {
-      "email": "blocked@example.com"
-    },
-    "expect": {
-      "status": 429,
-      "body": {
-        "messagePattern": "Usage \\$0(?:\\.0+)? / \\$0(?:\\.0+)? in 1 days"
-      }
-    }
+    "token": { "email": "blocked@example.com" },
+    "expect": { "status": 429, "body": { "messagePattern": "Usage \\$0(?:\\.0+)? / \\$0(?:\\.0+)? in 1 days" } }
   }
 ]

--- a/tests/fixtures/openrouter-options-custom.request.json
+++ b/tests/fixtures/openrouter-options-custom.request.json
@@ -2,7 +2,5 @@
   "description": "Preflight request that asks for specific headers",
   "method": "OPTIONS",
   "path": "/openrouter/v1/models",
-  "headers": {
-    "Access-Control-Request-Headers": "X-Custom-Header"
-  }
+  "headers": { "Access-Control-Request-Headers": "X-Custom-Header" }
 }

--- a/tests/fixtures/openrouter-success.json
+++ b/tests/fixtures/openrouter-success.json
@@ -2,29 +2,19 @@
   "description": "Authorized request for OpenRouter models",
   "method": "GET",
   "path": "/openrouter/v1/models",
-  "headers": {
-    "Authorization": "Bearer {{token}}"
-  },
+  "headers": { "Authorization": "Bearer {{token}}" },
   "mock": {
     "origin": "https://openrouter.ai",
     "path": "/api/v1/models",
     "method": "GET",
     "response": {
       "status": 200,
-      "headers": {
-        "content-type": "application/json"
-      },
+      "headers": { "content-type": "application/json" },
       "body": {
         "data": [
           {
             "id": "google/gemini-2.5-flash-lite",
-            "pricing": {
-              "prompt": 0.00001,
-              "completion": 0.00002,
-              "request": 0,
-              "internal_reasoning": 0,
-              "image": 0
-            }
+            "pricing": { "prompt": 0.00001, "completion": 0.00002, "request": 0, "internal_reasoning": 0, "image": 0 }
           }
         ]
       }
@@ -32,20 +22,12 @@
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
+    "headers": { "content-type": "application/json" },
     "body": {
       "data": [
         {
           "id": "google/gemini-2.5-flash-lite",
-          "pricing": {
-            "prompt": 0.00001,
-            "completion": 0.00002,
-            "request": 0,
-            "internal_reasoning": 0,
-            "image": 0
-          }
+          "pricing": { "prompt": 0.00001, "completion": 0.00002, "request": 0, "internal_reasoning": 0, "image": 0 }
         }
       ]
     }

--- a/tests/fixtures/openrouter-unauthorized.json
+++ b/tests/fixtures/openrouter-unauthorized.json
@@ -2,13 +2,6 @@
   "description": "OpenRouter request with invalid bearer token",
   "method": "GET",
   "path": "/openrouter/v1/models",
-  "headers": {
-    "Authorization": "Bearer invalid-token"
-  },
-  "response": {
-    "status": 401,
-    "body": {
-      "messageIncludes": "invalid"
-    }
-  }
+  "headers": { "Authorization": "Bearer invalid-token" },
+  "response": { "status": 401, "body": { "messageIncludes": "invalid" } }
 }

--- a/tests/fixtures/similarity-openai.response.json
+++ b/tests/fixtures/similarity-openai.response.json
@@ -1,17 +1,8 @@
 {
   "status": 200,
-  "headers": {
-    "content-type": "application/json"
-  },
+  "headers": { "content-type": "application/json" },
   "body": {
-    "data": [
-      { "embedding": [1, 0] },
-      { "embedding": [0, 1] },
-      { "embedding": [1, 0] },
-      { "embedding": [0, 1] }
-    ],
-    "usage": {
-      "prompt_tokens": 8
-    }
+    "data": [{ "embedding": [1, 0] }, { "embedding": [0, 1] }, { "embedding": [1, 0] }, { "embedding": [0, 1] }],
+    "usage": { "prompt_tokens": 8 }
   }
 }

--- a/tests/fixtures/similarity.json
+++ b/tests/fixtures/similarity.json
@@ -2,21 +2,8 @@
   "description": "Similarity endpoint invoking OpenAI embeddings",
   "method": "POST",
   "path": "/similarity",
-  "headers": {
-    "Authorization": "Bearer {{token}}",
-    "Content-Type": "application/json"
-  },
-  "body": {
-    "docs": [
-      "fox",
-      "dog"
-    ],
-    "topics": [
-      "fox",
-      "dog"
-    ],
-    "model": "text-embedding-3-small"
-  },
+  "headers": { "Authorization": "Bearer {{token}}", "Content-Type": "application/json" },
+  "body": { "docs": ["fox", "dog"], "topics": ["fox", "dog"], "model": "text-embedding-3-small" },
   "mock": {
     "origin": "https://api.openai.com",
     "path": "/v1/embeddings",
@@ -25,24 +12,7 @@
   },
   "response": {
     "status": 200,
-    "headers": {
-      "content-type": "application/json"
-    },
-    "body": {
-      "model": "text-embedding-3-small",
-      "similarity": [
-        [
-          1,
-          0
-        ],
-        [
-          0,
-          1
-        ]
-      ],
-      "usage": {
-        "prompt_tokens": 8
-      }
-    }
+    "headers": { "content-type": "application/json" },
+    "body": { "model": "text-embedding-3-small", "similarity": [[1, 0], [0, 1]], "usage": { "prompt_tokens": 8 } }
   }
 }

--- a/tests/fixtures/similarity.scenarios.json
+++ b/tests/fixtures/similarity.scenarios.json
@@ -1,12 +1,6 @@
-[
-  {
-    "name": "similarity-basic",
-    "request": "similarity",
-    "token": { "email": "test@example.com" },
-    "expect": {
-      "status": 200,
-      "body": { "responseFixture": "similarity.json" },
-      "usageDelta": 0.00000016
-    }
-  }
-]
+[{
+  "name": "similarity-basic",
+  "request": "similarity",
+  "token": { "email": "test@example.com" },
+  "expect": { "status": 200, "body": { "responseFixture": "similarity.json" }, "usageDelta": 0.00000016 }
+}]

--- a/tests/native-api-key.test.js
+++ b/tests/native-api-key.test.js
@@ -6,13 +6,6 @@ import { replyJson, seedUsage, setupWorkerFetchMock, workerFetch } from "./test-
 const fetchMock = setupWorkerFetchMock();
 
 const toHeaders = (headers) => headers instanceof Headers ? headers : new Headers(headers ?? {});
-const parseBody = (body) => {
-  if (!body) return null;
-  if (typeof body === "string") return JSON.parse(body);
-  if (body instanceof Uint8Array) return JSON.parse(Buffer.from(body).toString());
-  if (body.type === "Buffer") return JSON.parse(Buffer.from(body.data).toString());
-  return JSON.parse(String(body));
-};
 
 describe("Native API key detection", () => {
   test("detects OpenAI native keys (sk-)", async () => {
@@ -154,7 +147,6 @@ describe("Native API key behavior", () => {
 
   test("skips model pricing validation for native keys", async () => {
     const nativeKey = "sk-test-unknown-model-allowed";
-    let capturedBody;
 
     replyJson(fetchMock, {
       origin: "https://api.openai.com",
@@ -164,9 +156,6 @@ describe("Native API key behavior", () => {
         model: "unknown-model-no-pricing",
         usage: { prompt_tokens: 10, completion_tokens: 5 },
         choices: [{ message: { role: "assistant", content: "ok" } }],
-      },
-      assertRequest: (opts) => {
-        capturedBody = opts.body;
       },
     });
 

--- a/tests/native-api-key.test.js
+++ b/tests/native-api-key.test.js
@@ -1,0 +1,321 @@
+// @ts-check
+import { env } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import { replyJson, seedUsage, setupWorkerFetchMock, workerFetch } from "./test-helpers.js";
+
+const fetchMock = setupWorkerFetchMock();
+
+const toHeaders = (headers) => headers instanceof Headers ? headers : new Headers(headers ?? {});
+const parseBody = (body) => {
+  if (!body) return null;
+  if (typeof body === "string") return JSON.parse(body);
+  if (body instanceof Uint8Array) return JSON.parse(Buffer.from(body).toString());
+  if (body.type === "Buffer") return JSON.parse(Buffer.from(body.data).toString());
+  return JSON.parse(String(body));
+};
+
+describe("Native API key detection", () => {
+  test("detects OpenAI native keys (sk-)", async () => {
+    const nativeKey = "sk-test-openai-key-123456789";
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/models",
+      method: "GET",
+      body: { data: [{ id: "gpt-4" }] },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${nativeKey}`);
+      },
+    });
+
+    const response = await workerFetch("/openai/v1/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toEqual([{ id: "gpt-4" }]);
+  });
+
+  test("detects OpenRouter native keys (sk-or-)", async () => {
+    const nativeKey = "sk-or-test-openrouter-key-123456789";
+    replyJson(fetchMock, {
+      origin: "https://openrouter.ai",
+      path: "/api/v1/models",
+      method: "GET",
+      body: { data: [{ id: "test-model" }] },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        expect(headers.get("authorization")).toBe(`Bearer ${nativeKey}`);
+      },
+    });
+
+    const response = await workerFetch("/openrouter/v1/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("detects Gemini native keys (AIza)", async () => {
+    const nativeKey = "AIzaSyTestGeminiKey123456789abcdef";
+    replyJson(fetchMock, {
+      origin: "https://generativelanguage.googleapis.com",
+      path: "/v1beta/models",
+      method: "GET",
+      body: { models: [{ name: "gemini-1.5-pro" }] },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        expect(headers.get("x-goog-api-key")).toBe(nativeKey);
+      },
+    });
+
+    const response = await workerFetch("/geminiv1beta/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("Native API key behavior", () => {
+  test("bypasses JWT validation for native keys", async () => {
+    // This key is NOT a valid JWT, but it starts with sk-, so it should be treated as a native key
+    const nativeKey = "sk-invalid-jwt-but-valid-openai-key";
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/models",
+      method: "GET",
+      body: { data: [] },
+    });
+
+    const response = await workerFetch("/openai/v1/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    // Should succeed (200 or provider error), not 401 (JWT validation error)
+    expect(response.status).not.toBe(401);
+  });
+
+  test("skips budget check for native keys", async () => {
+    // Seed usage at max limit (which would normally block requests)
+    await seedUsage({ "any@example.com": { "2024-01-01": 1000000 } });
+
+    const nativeKey = "sk-test-key-should-bypass-budget";
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/models",
+      method: "GET",
+      body: { data: [] },
+    });
+
+    const response = await workerFetch("/openai/v1/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    // Should not return 429 (budget exceeded)
+    expect(response.status).not.toBe(429);
+    expect(response.status).toBe(200);
+  });
+
+  test("does not track cost for native key requests", async () => {
+    await seedUsage({});
+    const nativeKey = "sk-test-key-no-cost-tracking";
+
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/chat/completions",
+      method: "POST",
+      body: {
+        model: "gpt-4o-mini",
+        usage: { prompt_tokens: 1000000, completion_tokens: 500000 }, // Huge usage
+        choices: [{ message: { role: "assistant", content: "test" } }],
+      },
+    });
+
+    const response = await workerFetch("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${nativeKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+
+    // Cost should remain at 0 since native keys don't track costs
+    // Note: We can't directly check the cost database without an AIPipe token,
+    // but we verify the request succeeded without updating any cost
+  });
+
+  test("skips model pricing validation for native keys", async () => {
+    const nativeKey = "sk-test-unknown-model-allowed";
+    let capturedBody;
+
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/chat/completions",
+      method: "POST",
+      body: {
+        model: "unknown-model-no-pricing",
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+        choices: [{ message: { role: "assistant", content: "ok" } }],
+      },
+      assertRequest: (opts) => {
+        capturedBody = opts.body;
+      },
+    });
+
+    // With native key, unknown model should be allowed (no pricing validation)
+    const response = await workerFetch("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${nativeKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "unknown-model-no-pricing",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.model).toBe("unknown-model-no-pricing");
+  });
+
+  test("uses native key directly instead of environment key", async () => {
+    const nativeKey = "sk-my-personal-openai-key-12345";
+
+    replyJson(fetchMock, {
+      origin: "https://api.openai.com",
+      path: "/v1/chat/completions",
+      method: "POST",
+      body: {
+        model: "gpt-4o-mini",
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+        choices: [{ message: { role: "assistant", content: "hi" } }],
+      },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        // Should use the native key, NOT the environment key
+        expect(headers.get("authorization")).toBe(`Bearer ${nativeKey}`);
+        expect(headers.get("authorization")).not.toBe(`Bearer ${env.OPENAI_API_KEY}`);
+      },
+    });
+
+    const response = await workerFetch("/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${nativeKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("Native API key restrictions", () => {
+  test("rejects native keys for usage endpoint", async () => {
+    const nativeKey = "sk-test-key-usage-denied";
+    const response = await workerFetch("/usage", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toContain("AIPipe JWT token");
+  });
+
+  test("rejects native keys for admin endpoint", async () => {
+    const nativeKey = "sk-test-key-admin-denied";
+    const response = await workerFetch("/admin/usage", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toContain("AIPipe JWT token");
+  });
+
+  test("rejects Gemini native keys for admin endpoint", async () => {
+    const nativeKey = "AIzaSyAdminDeniedKey123456789";
+    const response = await workerFetch("/admin/usage", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toContain("AIPipe JWT token");
+  });
+});
+
+describe("OpenRouter native key specifics", () => {
+  test("does not add AIPipe referer headers for native keys", async () => {
+    const nativeKey = "sk-or-user-openrouter-key-abc123";
+
+    replyJson(fetchMock, {
+      origin: "https://openrouter.ai",
+      path: "/api/v1/models",
+      method: "GET",
+      body: { data: [] },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        // Native keys should NOT have AIPipe's referer headers
+        expect(headers.get("http-referer")).not.toBe("https://aipipe.org/");
+        expect(headers.get("x-title")).not.toBe("AIPipe");
+      },
+    });
+
+    const response = await workerFetch("/openrouter/v1/models", {
+      headers: { Authorization: `Bearer ${nativeKey}` },
+    });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("Gemini native key specifics", () => {
+  test("converts Authorization header to x-goog-api-key for Gemini", async () => {
+    const nativeKey = "AIzaSyGeminiNativeKey123456789abc";
+
+    replyJson(fetchMock, {
+      origin: "https://generativelanguage.googleapis.com",
+      path: "/v1beta/models/gemini-1.5-pro:generateContent",
+      method: "POST",
+      body: {
+        model: "gemini-1.5-pro",
+        candidates: [{ content: { parts: [{ text: "Hello!" }] } }],
+        usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+      },
+      assertRequest: (opts) => {
+        const headers = toHeaders(opts.headers);
+        // Should convert Authorization: Bearer to x-goog-api-key
+        expect(headers.get("x-goog-api-key")).toBe(nativeKey);
+        expect(headers.get("authorization")).toBeNull();
+      },
+    });
+
+    const response = await workerFetch("/geminiv1beta/models/gemini-1.5-pro:generateContent", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${nativeKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: "Hi" }] }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Allow users to send their own provider API keys (OpenAI, OpenRouter, Gemini) instead of AIPipe JWT tokens. This enables pass-through mode where requests bypass AIPipe's JWT validation, budget checks, and cost tracking.

Key features:
- Detect native keys by prefix patterns (sk- for OpenAI/OpenRouter, AIza for Gemini)
- Skip model pricing validation for native keys
- Forward native keys directly to providers instead of using AIPipe's keys
- Block access to /usage and /admin endpoints with native keys
- Comprehensive test suite for native key functionality

This provides flexibility for users who want to use their own keys while still benefiting from AIPipe's proxy infrastructure.